### PR TITLE
Allow multiple prefixes to be filtered from formatted titles

### DIFF
--- a/classes/class-homepage-control-admin.php
+++ b/classes/class-homepage-control-admin.php
@@ -261,7 +261,7 @@ foreach ( $components as $k => $v ) {
 	 * @return  string A formatted title. If no formatting is possible, return the key.
 	 */
 	private function _maybe_format_title ( $key ) {
-		$prefix = (string)apply_filters( 'hompage_control_prefix', 'woo_display_' );
+		$prefix = (array) apply_filters( 'hompage_control_prefix', array( 'woo_display_' ) );
 		$title = $key;
 
 		$title = str_replace( $prefix, '', $title );


### PR DESCRIPTION
`str_replace()` will accept both strings and arrays, why force a filterable prefix to be a string where only one prefix could be passed, when we can just make it an array.

http://php.net/str_replace
http://php.net/manual/en/language.pseudo-types.php#language.types.mixed