### PR TITLE
Remove controls

### DIFF
--- a/classes/class-homepage-control-customizer-control.php
+++ b/classes/class-homepage-control-customizer-control.php
@@ -40,6 +40,9 @@ class Homepage_Control_Customizer_Control extends WP_Customize_Control {
 					<?php $components = $this->_reorder_components( $components, $order ); ?>
 					<?php foreach ( $components as $k => $v ) : ?>
 						<?php
+							if ( ! function_exists( $k ) ) {
+								continue;
+							}
 							$class = '';
 							if ( in_array( $k, $disabled ) ) {
 								$class = 'disabled';

--- a/classes/class-homepage-control-customizer-control.php
+++ b/classes/class-homepage-control-customizer-control.php
@@ -38,17 +38,29 @@ class Homepage_Control_Customizer_Control extends WP_Customize_Control {
 				?>
 				<ul class="homepage-control">
 					<?php $components = $this->_reorder_components( $components, $order ); ?>
-					<?php foreach ( $components as $k => $v ) : ?>
+					<?php foreach ( $components as $id => $title ) : ?>
 						<?php
-							if ( ! function_exists( $k ) ) {
-								continue;
-							}
 							$class = '';
-							if ( in_array( $k, $disabled ) ) {
+							if ( in_array( $id, $disabled ) ) {
 								$class = 'disabled';
 							}
+
+							/**
+							 * Filter the control title.
+							 *
+							 * @since 2.0.1
+							 *
+							 * @param string $title The control title.
+							 * @param string $id The action hook function ID.
+							 */
+							$title = apply_filters( 'homepage_control_title', $title, $id );
+
+							// Nothing to display.
+							if ( empty( $title ) ) {
+								continue;
+							}
 						?>
-						<li id="<?php echo esc_attr( $k ); ?>" class="<?php echo $class; ?>"><span class="visibility"></span><?php echo esc_attr( $v ); ?></li>
+						<li id="<?php echo esc_attr( $id ); ?>" class="<?php echo $class; ?>"><span class="visibility"></span><?php echo esc_attr( $title ); ?></li>
 					<?php endforeach; ?>
 				</ul>
 				<input type="hidden" <?php $this->link(); ?> value="<?php echo esc_attr( $this->value() ); ?>"/>


### PR DESCRIPTION
If you have added actions and saved the settings in the Customizer then deactivate the plugin that added the controls they display as an empty item with a checkbox. By doing a check for the function it hides the empty boxes. Though you should probably do a check for the class method if it was added that way, as well.

![empty-boxes](https://cloud.githubusercontent.com/assets/62798/7899580/60965da4-06dd-11e5-8791-b737268d404e.png)
