### PR TITLE
Some minor adjustments

### DIFF
--- a/classes/class-homepage-control-customizer-control.php
+++ b/classes/class-homepage-control-customizer-control.php
@@ -21,7 +21,7 @@ class Homepage_Control_Customizer_Control extends WP_Customize_Control {
 	 */
 	public function render_content() {
 		if ( ! is_array( $this->choices ) || ! count( $this->choices ) ) {
-			printf( __( 'No homepage components found. See the %sdocs%s for details of available homepage component plugins/themes.', 'homepage-control' ), '<a href="' . esc_url( 'http://docs.woothemes.com/document/homepage-control/' ) . '">', '</a>' );
+			printf( __( 'No homepage components found. Please contact your theme author to make your theme compatible with Homepage Control or see this %sguide%s for details on how to do this yourself.', 'homepage-control' ), '<a href="' . esc_url( 'https://docs.woocommerce.com/document/make-your-theme-compatible-with-homepage-control/' ) . '">', '</a>' );
 		} else {
 			$components         = $this->choices;
 			$order              = $this->value();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woothemes,mattyza,jameskoster,tiagonoronha
 Donate link: http://woothemes.com/
 Tags: homepage, hooks, theme-mod, components, customizer
 Requires at least: 3.8.1
-Tested up to: 4.5.3
+Tested up to: 4.6
 Stable tag: 2.0.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Resolves #22 and #20 

Instead of completely hiding this section, we'll notify the user that the theme doesn't support homepage control and add link to relevant docs page the client/theme author can reference to add theme support for homepage control

Checked `4.6` compatibility

Cheers!

@jeffikus 